### PR TITLE
Fix tree generation logic

### DIFF
--- a/src/main/java/com/unseen/nb/common/blocks/BlockCrimsonFungusTree.java
+++ b/src/main/java/com/unseen/nb/common/blocks/BlockCrimsonFungusTree.java
@@ -64,13 +64,13 @@ public class BlockCrimsonFungusTree extends BlockPlantBase implements IGrowable 
                 //Crimson
                 if(randTreeSize == 1) {
                     WorldGenNB tree = ModRand.choice(c_small_trees);
-                    tree.generate(world, random, pos.add(-2,0,-2));
+                    tree.generate(world, random, pos);
                 } else if (randTreeSize == 2) {
                     WorldGenNB tree = ModRand.choice(c_medium_trees);
-                    tree.generate(world, random, pos.add(-2,0,-2));
+                    tree.generate(world, random, pos);
                 } else {
                     WorldGenNB large_tree = ModRand.choice(c_large_trees);
-                    large_tree.generate(world, random, pos.add(- 3,  0,- 3));
+                    large_tree.generate(world, random, pos);
                 }
         }
 

--- a/src/main/java/com/unseen/nb/common/blocks/BlockFungusTree.java
+++ b/src/main/java/com/unseen/nb/common/blocks/BlockFungusTree.java
@@ -72,13 +72,13 @@ public class BlockFungusTree extends BlockPlantBase implements IGrowable {
                 //Warped
                 if(randTreeSize == 1) {
                     WorldGenNB tree = ModRand.choice(small_trees);
-                    tree.generate(world, random, pos.add(-2,0,-2));
+                    tree.generate(world, random, pos);
                 } else if (randTreeSize == 2) {
                     WorldGenNB tree = ModRand.choice(medium_trees);
-                    tree.generate(world, random, pos.add(-2,0,-2));
+                    tree.generate(world, random, pos);
                 } else {
                     WorldGenNB large_tree = ModRand.choice(large_trees);
-                    large_tree.generate(world, random, pos.add(- 3,  0,- 3));
+                    large_tree.generate(world, random, pos);
                 }
         }
 

--- a/src/main/java/com/unseen/nb/common/world/terrain/trees/WorldGenCrimsonTree.java
+++ b/src/main/java/com/unseen/nb/common/world/terrain/trees/WorldGenCrimsonTree.java
@@ -22,13 +22,13 @@ public class WorldGenCrimsonTree extends WorldGenNB {
 
     @Override
     public boolean generate(World worldIn, Random rand, BlockPos position) {
-        if(size == 1) {
+        if (size == 1) {
             //small trees
             if(worldIn.isAirBlock(position.add(0, 7, 0)) && worldIn.getBlockState(position.down()) == ModBlocks.CRIMSON_GRASS.getDefaultState()) {
                 if(worldIn.getBlockState(position) == ModBlocks.CRIMSON_FUNGUS.getDefaultState()) {
                     worldIn.setBlockToAir(position);
                 }
-                return super.generate(worldIn, rand, position);
+                return super.generate(worldIn, rand, position.add(-2, 0, -2));
             }
         } else if (size == 2) {
             //medium trees
@@ -36,7 +36,7 @@ public class WorldGenCrimsonTree extends WorldGenNB {
                 if(worldIn.getBlockState(position) == ModBlocks.CRIMSON_FUNGUS.getDefaultState()) {
                     worldIn.setBlockToAir(position);
                 }
-                return super.generate(worldIn, rand, position);
+                return super.generate(worldIn, rand, position.add(-2, 0, -2));
             }
         } else {
             //large trees
@@ -44,7 +44,7 @@ public class WorldGenCrimsonTree extends WorldGenNB {
                 if(worldIn.getBlockState(position) == ModBlocks.CRIMSON_FUNGUS.getDefaultState()) {
                     worldIn.setBlockToAir(position);
                 }
-                return super.generate(worldIn, rand, position);
+                return super.generate(worldIn, rand, position.add(-3, 0, -3));
             }
         }
         return false;

--- a/src/main/java/com/unseen/nb/common/world/terrain/trees/WorldGenWarpedTree.java
+++ b/src/main/java/com/unseen/nb/common/world/terrain/trees/WorldGenWarpedTree.java
@@ -10,9 +10,6 @@ import java.util.Random;
 public class WorldGenWarpedTree extends WorldGenNB {
     int size;
 
-
-
-
     public WorldGenWarpedTree(String structureName, int size) {
         super("trees/warped/" + structureName);
         this.size = size;
@@ -27,7 +24,7 @@ public class WorldGenWarpedTree extends WorldGenNB {
                 if(worldIn.getBlockState(position) == ModBlocks.WARPED_FUNGUS.getDefaultState()) {
                     worldIn.setBlockToAir(position);
                 }
-                return super.generate(worldIn, rand, position);
+                return super.generate(worldIn, rand, position.add(-2, 0, -2));
             }
         } else if (size == 2) {
             //medium trees
@@ -35,7 +32,7 @@ public class WorldGenWarpedTree extends WorldGenNB {
                 if(worldIn.getBlockState(position) == ModBlocks.WARPED_FUNGUS.getDefaultState()) {
                     worldIn.setBlockToAir(position);
                 }
-                return super.generate(worldIn, rand, position);
+                return super.generate(worldIn, rand, position.add(-2, 0, -2));
             }
         } else {
             //large trees
@@ -43,7 +40,7 @@ public class WorldGenWarpedTree extends WorldGenNB {
                 if(worldIn.getBlockState(position) == ModBlocks.WARPED_FUNGUS.getDefaultState()) {
                     worldIn.setBlockToAir(position);
                 }
-                return super.generate(worldIn, rand, position);
+                return super.generate(worldIn, rand, position.add(-3, 0, -3));
             }
         }
         return false;


### PR DESCRIPTION
It fixes tree generation logic. Current implementation checks block under after the coordinate transformations, which creates behaviour that tree can not grow on single Nylium block. This fix moves the coordinate transformation after that check.